### PR TITLE
Use version param from route if exists

### DIFF
--- a/src/PrototypeRouteListener.php
+++ b/src/PrototypeRouteListener.php
@@ -105,8 +105,13 @@ class PrototypeRouteListener extends AbstractListenerAggregate
                 continue;
             }
 
-            $config['router']['routes'][$routeName]['options']['route'] = $this->versionRoutePrefix
-                . $config['router']['routes'][$routeName]['options']['route'];
+            if (false === strpos(
+                $config['router']['routes'][$routeName]['options']['route'],
+                $this->versionRoutePrefix
+            )) {
+                $config['router']['routes'][$routeName]['options']['route'] = $this->versionRoutePrefix
+                .$config['router']['routes'][$routeName]['options']['route'];
+            }
 
             $config['router']['routes'][$routeName]['options'] = ArrayUtils::merge(
                 $config['router']['routes'][$routeName]['options'],

--- a/test/PrototypeRouteListenerTest.php
+++ b/test/PrototypeRouteListenerTest.php
@@ -35,6 +35,15 @@ class PrototypeRouteListenerTest extends TestCase
                         ),
                     ),
                 ),
+                'group' => array(
+                    'type' => 'Segment',
+                    'options' => array(
+                        'route' => '/group[/v:version][/:id]',
+                        'defaults' => array(
+                            'controller' => 'GroupController',
+                        ),
+                    ),
+                ),
             ),
         ));
         $this->configListener = new ConfigListener();
@@ -79,15 +88,16 @@ class PrototypeRouteListenerTest extends TestCase
     {
         return array(
             'status' => array(array('status'), 1),
-            'user'   => array(array('user'), 2),
-            'both'   => array(array('status', 'user')),
+            'user' => array(array('user'), 2),
+            'both' => array(array('status', 'user'), null),
+            'group' => array(array('group'), null, 6),
         );
     }
 
     /**
      * @dataProvider routesForWhichToVerifyPrototype
      */
-    public function testPrototypeAddedToRoutesProvidedToListener(array $routes, $apiVersion = null)
+    public function testPrototypeAddedToRoutesProvidedToListener(array $routes, $apiVersion = null, $position = 0)
     {
         $this->config['zf-versioning'] = array(
             'uri' => $routes
@@ -115,7 +125,7 @@ class PrototypeRouteListenerTest extends TestCase
             $options = $routeConfig['options'];
 
             $this->assertArrayHasKey('route', $options);
-            $this->assertSame(0, strpos($options['route'], '[/v:version]'));
+            $this->assertSame($position, strpos($options['route'], '[/v:version]'));
 
             $this->assertArrayHasKey('constraints', $options);
             $this->assertArrayHasKey('version', $options['constraints']);


### PR DESCRIPTION
I'm having the same problem with @bvarent as described in #8. In order to get over it I've changed the PrototypeRouteListener class in order to use the existing route version param if exists. With this you can specify the placement of the version in the url.

e.g.
The following configuration will produce /api/v1/user* urls

```php
$routes = array(
    'api' => array(
        'type' => 'Segment',
        'options' => array(
            'route' => '/api[/v:version]',
        ),
        'child_routes' => array(
            'user' => array(
                'type' => 'Segment',
                    'options' => array(
                        'route' => '/user[/:id]',
                        'defaults' => array(
                            'controller' => 'UserController',
                        ),
                    ),
                ),
            ),
        ),
    ),
);
```
