### PR TITLE
[#12] Do not check if the request is an OPTIONS request

### DIFF
--- a/src/VersionListener.php
+++ b/src/VersionListener.php
@@ -9,7 +9,6 @@ namespace ZF\Versioning;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\ListenerAggregateInterface;
 use Zend\EventManager\ListenerAggregateTrait;
-use Zend\Http\Request as HttpRequest;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch as V2RouteMatch;
 use Zend\Router\RouteMatch;
@@ -33,13 +32,6 @@ class VersionListener implements ListenerAggregateInterface
      */
     public function onRoute(MvcEvent $e)
     {
-        $request = $e->getRequest();
-        if ($request instanceof HttpRequest
-            && $request->isOptions()
-        ) {
-            return;
-        }
-
         $routeMatches = $e->getRouteMatch();
         if (! ($routeMatches instanceof RouteMatch || $routeMatches instanceof V2RouteMatch)) {
             return;

--- a/test/VersionListenerTest.php
+++ b/test/VersionListenerTest.php
@@ -9,6 +9,7 @@ namespace ZFTest\Versioning;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\Test\EventListenerIntrospectionTrait;
+use Zend\Http\Request;
 use Zend\Mvc\MvcEvent;
 use ZF\Versioning\VersionListener;
 
@@ -74,6 +75,24 @@ class VersionListenerTest extends TestCase
 
     public function testAltersControllerVersionNamespaceToReflectVersion()
     {
+        $matches = $this->event->getRouteMatch();
+        $matches->setParam('version', 2);
+        $matches->setParam('controller', 'Foo\V1\Rest\Bar\Controller');
+        $result = $this->listener->onRoute($this->event);
+        $this->assertInstanceOf($this->getRouteMatchClass(), $result);
+        $this->assertEquals('Foo\V2\Rest\Bar\Controller', $result->getParam('controller'));
+    }
+
+    /**
+     * @group 12
+     */
+    public function testAltersControllerVersionNamespaceToReflectVersionForOptionsRequests()
+    {
+        $request = $this->prophesize(Request::class);
+        $request->isOptions()->shouldNotBeCalled();
+
+        $this->event->setRequest($request->reveal());
+
         $matches = $this->event->getRouteMatch();
         $matches->setParam('version', 2);
         $matches->setParam('controller', 'Foo\V1\Rest\Bar\Controller');


### PR DESCRIPTION
Doing so defaults the matched controller to v1, which may present different options than a later version.

Fixes #12.