### PR TITLE
Make segment route type the default

### DIFF
--- a/src/PrototypeRouteListener.php
+++ b/src/PrototypeRouteListener.php
@@ -109,6 +109,8 @@ class PrototypeRouteListener implements ListenerAggregateInterface
                 continue;
             }
 
+            $config['router']['routes'][$routeName]['type'] = 'segment';
+
             if (false === strpos(
                 $config['router']['routes'][$routeName]['options']['route'],
                 $this->versionRoutePrefix

--- a/test/PrototypeRouteListenerTest.php
+++ b/test/PrototypeRouteListenerTest.php
@@ -44,6 +44,15 @@ class PrototypeRouteListenerTest extends TestCase
                         ],
                     ],
                 ],
+                'literal' => [
+                    'type' => 'literal',
+                    'options' => [
+                        'route' => '/group',
+                        'defaults' => [
+                            'controller' => 'GroupController',
+                        ],
+                    ],
+                ],
             ],
         ]];
         $this->configListener = new ConfigListener();
@@ -119,8 +128,11 @@ class PrototypeRouteListenerTest extends TestCase
 
         $routesConfig = $routerConfig['routes'];
         foreach ($routes as $routeName) {
+
             $this->assertArrayHasKey($routeName, $routesConfig);
             $routeConfig = $routesConfig[$routeName];
+
+            $this->assertSame('segment', $routeConfig['type']);
             $this->assertArrayHasKey('options', $routeConfig);
             $options = $routeConfig['options'];
 


### PR DESCRIPTION
`segment` should be set as type when merging routes. Could effect PR #13
