### PR TITLE
Use zf_ver_version instead of version

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ information for URL based versioning.  This key is an array of route names that 
 `router.routes` configuration.  If a particular route is a child route, the chain will happen at the
 top-most ancestor.
 
-The route matching segment consists of a rule of `[/v:version]` while specifying a constraint
+The route matching segment consists of a rule of `[/v:zf_ver_version]` while specifying a constraint
 of digits only for the version parameter.
 
 Example:

--- a/src/PrototypeRouteListener.php
+++ b/src/PrototypeRouteListener.php
@@ -22,7 +22,7 @@ class PrototypeRouteListener implements ListenerAggregateInterface
      *
      * @var string
      */
-    protected $versionRoutePrefix = '[/v:version]';
+    protected $versionRoutePrefix = '[/v:zf_ver_version]';
 
     /**
      * Constraints to introduce in versioned routes
@@ -31,10 +31,10 @@ class PrototypeRouteListener implements ListenerAggregateInterface
      */
     protected $versionRouteOptions = [
         'defaults'    => [
-            'version' => 1,
+            'zf_ver_version' => 1,
         ],
         'constraints' => [
-            'version' => '\d+',
+            'zf_ver_version' => '\d+',
         ],
     ];
 
@@ -84,7 +84,7 @@ class PrototypeRouteListener implements ListenerAggregateInterface
 
         // Override default version of 1 with user-specified config value, if available.
         if (isset($config['zf-versioning']['default_version'])) {
-            $this->versionRouteOptions['defaults']['version'] = $config['zf-versioning']['default_version'];
+            $this->versionRouteOptions['defaults']['zf_ver_version'] = $config['zf-versioning']['default_version'];
         }
 
         // Pre-process route list to strip out duplicates (often a result of

--- a/test/PrototypeRouteListenerTest.php
+++ b/test/PrototypeRouteListenerTest.php
@@ -38,7 +38,7 @@ class PrototypeRouteListenerTest extends TestCase
                 'group' => [
                     'type' => 'Segment',
                     'options' => [
-                        'route' => '/group[/v:version][/:id]',
+                        'route' => '/group[/v:zf_ver_version][/:id]',
                         'defaults' => [
                             'controller' => 'GroupController',
                         ],
@@ -125,15 +125,15 @@ class PrototypeRouteListenerTest extends TestCase
             $options = $routeConfig['options'];
 
             $this->assertArrayHasKey('route', $options);
-            $this->assertSame($position, strpos($options['route'], '[/v:version]'));
+            $this->assertSame($position, strpos($options['route'], '[/v:zf_ver_version]'));
 
             $this->assertArrayHasKey('constraints', $options);
-            $this->assertArrayHasKey('version', $options['constraints']);
-            $this->assertEquals('\d+', $options['constraints']['version']);
+            $this->assertArrayHasKey('zf_ver_version', $options['constraints']);
+            $this->assertEquals('\d+', $options['constraints']['zf_ver_version']);
 
             $this->assertArrayHasKey('defaults', $options);
-            $this->assertArrayHasKey('version', $options['defaults']);
-            $this->assertEquals($apiVersion, $options['defaults']['version']);
+            $this->assertArrayHasKey('zf_ver_version', $options['defaults']);
+            $this->assertEquals($apiVersion, $options['defaults']['zf_ver_version']);
         }
     }
 }


### PR DESCRIPTION
The route parameter version is a reserved word because of the handling of the version in this module.  This fixes the named route parameter to `zf_ver_version` so version may be a field in a Doctrine entity.  If the reserved word version is also a field name in an entity it will break:  https://github.com/zfcampus/zf-apigility-doctrine/issues/275

cc @jensstalder
